### PR TITLE
Use new team drives arg instead of deprecated one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.0.2] - 2022-02-07
 ### Added
 - Add click command for generating gdrive token
@@ -12,3 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.1] - 2021-11-26
 ### Added
 - Google drive client.
+
+[Unreleased]: https://github.com/octoenergy/tentaclio-gdrive/compare/0.0.2...HEAD
+[0.0.2]: https://github.com/octoenergy/tentaclio-gdrive/compare/0.0.1...0.0.2
+[0.0.1]: https://github.com/octoenergy/tentaclio-gdrive/releases/tag/0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix writing to shared drives by using the appropriate non-deprecated API parameter
 
 ## [0.0.2] - 2022-02-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.3] - 2022-08-12
 ### Fixed
 - Fix writing to shared drives by using the appropriate non-deprecated API parameter
 
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Google drive client.
 
-[Unreleased]: https://github.com/octoenergy/tentaclio-gdrive/compare/0.0.2...HEAD
+[Unreleased]: https://github.com/octoenergy/tentaclio-gdrive/compare/0.0.3...HEAD
+[0.0.3]: https://github.com/octoenergy/tentaclio-gdrive/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/octoenergy/tentaclio-gdrive/compare/0.0.1...0.0.2
 [0.0.1]: https://github.com/octoenergy/tentaclio-gdrive/releases/tag/0.0.1

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.3] - 2022-02-07
+## [0.0.2] - 2022-02-07
 ### Added
-  - Add click command for generating gdrive token
-  - Bump tentaclio install requirement >= 1.0.3
+- Add click command for generating gdrive token
+- Bump tentaclio install requirement >= 1.0.3
 
 ## [0.0.1] - 2021-11-26
 ### Added
- - Google drive client.
+- Google drive client.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools.command.install import install
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-VERSION = "0.0.2"
+VERSION = "0.0.3"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio_gdrive/clients/google_drive_client.py
+++ b/src/tentaclio_gdrive/clients/google_drive_client.py
@@ -244,7 +244,7 @@ class GoogleDriveFSClient(base_client.BaseClient["GoogleDriveFSClient"]):
         leaf_descriptor = self._get_leaf_descriptor()
         args = {
             "fileId": leaf_descriptor.id_,
-            "supportsTeamDrives": True,
+            "supportsAllDrives": True,
         }
         self._service.files().delete(**args).execute()  # type: ignore
 
@@ -311,7 +311,7 @@ class _DownloadRequest(_GoogleDriveRequest):
     def __init__(self, service: Any, file_id: str, writer: protocols.ByteWriter, **kwargs):
         super().__init__(service, kwargs)
         self.args["fileId"] = file_id
-        self.args["supportsTeamDrives"] = True
+        self.args["supportsAllDrives"] = True
         self.writer = writer
 
     def execute(self):
@@ -329,8 +329,6 @@ class _CreateRequest(_GoogleDriveRequest):
         self, service: Any, name: str, parent_id: str, reader: protocols.ByteReader, **kwargs
     ):
         super().__init__(service, kwargs)
-        # self.args["parents"] = [parent_id]
-        self.args["supportsTeamDrives"] = True
         self.args["name"] = name
         self.args["parents"] = [parent_id]
         self.reader = reader
@@ -342,6 +340,7 @@ class _CreateRequest(_GoogleDriveRequest):
         self.service.files().create(
             body=self.args,
             media_body=media_body,
+            supportsAllDrives=True,
         ).execute()
 
 
@@ -353,7 +352,7 @@ class _UpdateRequest(_GoogleDriveRequest):
     ):
         super().__init__(service, kwargs)
         # self.args["parents"] = [parent_id]
-        self.args["supportsTeamDrives"] = True
+        self.args["supportsAllDrives"] = True
         self.args["fileId"] = file_id
         self.name = name
         self.reader = reader
@@ -397,7 +396,7 @@ class _ListFilesRequest(_Lister[_GoogleFileDescriptor]):
     def __init__(self, service: Any, url_base: Optional[str] = None, **kwargs):
         super().__init__(service, **kwargs)
         # Get team drives too
-        self.args["supportsTeamDrives"] = True
+        self.args["supportsAllDrives"] = True
         self.args["includeTeamDriveItems"] = True
         self.args["fields"] = "files(id, name, mimeType, parents)"
         self.url_base = url_base


### PR DESCRIPTION
The calling signature for using this argument when creating files was also incorrect, so I update it to be a argument of the actual method rather than being in the args variable. Previously, trying to write to shared drives failed.